### PR TITLE
Fix video upload type detection, increase size limit, and preload images for instant page renders

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,7 @@ const storage = multer.diskStorage({
 const upload = multer({
   storage: storage,
   limits: {
-    fileSize: 10 * 1024 * 1024, // 10MB limit
+    fileSize: 500 * 1024 * 1024, // 500MB limit (supports video uploads)
   },
   fileFilter: function (req, file, cb) {
     // Allow images and videos
@@ -288,7 +288,7 @@ app.use((error, req, res, next) => {
     if (error.code === "LIMIT_FILE_SIZE") {
       return res
         .status(400)
-        .json({ error: "File too large. Maximum size is 10MB." });
+        .json({ error: "File too large. Maximum size is 500MB." });
     }
   }
   res.status(500).json({ error: error.message });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,3 +20,16 @@ export const resolveImagePath = (url: string) => {
 
   return url;
 };
+
+export const preloadImages = (urls: string[]): Promise<void> =>
+  Promise.all(
+    urls.filter(Boolean).map(
+      (url) =>
+        new Promise<void>((resolve) => {
+          const img = new window.Image();
+          img.onload = () => resolve();
+          img.onerror = () => resolve();
+          img.src = resolveImagePath(url);
+        }),
+    ),
+  ).then(() => undefined);

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -98,9 +98,14 @@ const Admin = () => {
   ) => {
     if (!file) return;
 
-    // Check file size (10MB limit)
-    if (file.size > 10 * 1024 * 1024) {
-      alert("File too large. Maximum size is 10MB.");
+    const isVideo = file.type.startsWith("video/");
+    const maxSize = isVideo ? 500 * 1024 * 1024 : 10 * 1024 * 1024;
+    if (file.size > maxSize) {
+      alert(
+        isVideo
+          ? "Video too large. Maximum size is 500MB."
+          : "Image too large. Maximum size is 10MB.",
+      );
       return;
     }
 
@@ -1349,6 +1354,12 @@ const Admin = () => {
                               onChange={(e) => {
                                 const file = e.target.files?.[0];
                                 if (file) {
+                                  const detectedType = file.type.startsWith(
+                                    "video/",
+                                  )
+                                    ? "video"
+                                    : "image";
+                                  updateMediaItem(index, "type", detectedType);
                                   handleFileUpload(file, (url) => {
                                     updateMediaItem(index, "url", url);
                                   });

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -4,7 +4,7 @@ import { Calendar, MapPin } from "lucide-react";
 import { Event, Musician } from "@/lib/types/events";
 import { eventsAPI, musiciansAPI } from "@/lib/api";
 import MusiciansList from "@/components/MusiciansList";
-import { resolveImagePath } from "@/lib/utils";
+import { resolveImagePath, preloadImages } from "@/lib/utils";
 
 const EventDetail = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -14,59 +14,52 @@ const EventDetail = () => {
   const [eventMusicians, setEventMusicians] = useState<Musician[]>([]);
 
   useEffect(() => {
-    // Find the event by slug from API
-    const loadEvent = async () => {
+    const loadEventData = async () => {
       setLoading(true);
       try {
-        console.log("Loading event for slug:", slug);
-        const foundEvent = await eventsAPI.getBySlug(slug!);
-        console.log("Found event:", foundEvent);
+        const [foundEvent, allMusicians] = await Promise.all([
+          eventsAPI.getBySlug(slug!).catch(async () => {
+            const events = await eventsAPI.getAll();
+            return events.find((e: Event) => e.slug === slug) ?? null;
+          }),
+          musiciansAPI.getAll().catch(() => []),
+        ]);
+
         setEvent(foundEvent);
+
+        if (foundEvent) {
+          const musicians = (foundEvent.musicians || [])
+            .map((id: string) =>
+              allMusicians.find((m: Musician) => m.id === id),
+            )
+            .filter(
+              (m: Musician | undefined): m is Musician => m !== undefined,
+            );
+          setEventMusicians(musicians);
+
+          const imageUrls = [
+            ...(foundEvent.media || [])
+              .filter(
+                (m: { type: string; url: string }) =>
+                  m.type === "image" && m.url,
+              )
+              .map((m: { url: string }) => m.url),
+            ...musicians
+              .filter((m: Musician) => m.photo)
+              .map((m: Musician) => m.photo),
+          ];
+          await preloadImages(imageUrls);
+        }
       } catch (error) {
         console.error("Failed to load event:", error);
-        // Fallback to getAll if getBySlug fails
-        try {
-          const events = await eventsAPI.getAll();
-          const fallbackEvent = events.find((e: Event) => e.slug === slug);
-          setEvent(fallbackEvent || null);
-        } catch (fallbackError) {
-          console.error("Fallback also failed:", fallbackError);
-          setEvent(null);
-        }
+        setEvent(null);
       } finally {
         setLoading(false);
       }
     };
 
-    loadEvent();
+    loadEventData();
   }, [slug]);
-
-  useEffect(() => {
-    const loadMusicians = async () => {
-      if (!event) {
-        setEventMusicians([]);
-        return;
-      }
-
-      try {
-        const allMusicians = await musiciansAPI.getAll();
-        const musicians = event.musicians
-          .map((musicianId) =>
-            allMusicians.find((m: Musician) => m.id === musicianId),
-          )
-          .filter(
-            (musician): musician is NonNullable<typeof musician> =>
-              musician !== undefined,
-          );
-        setEventMusicians(musicians);
-      } catch (error) {
-        console.error("Failed to load musicians:", error);
-        setEventMusicians([]);
-      }
-    };
-
-    loadMusicians();
-  }, [event]);
 
   if (loading) {
     return (
@@ -100,7 +93,8 @@ const EventDetail = () => {
 
   const prevMedia = () => {
     setCurrentMediaIndex(
-      (prev) => (prev - 1 + (event.media?.length ?? 1)) % (event.media?.length ?? 1),
+      (prev) =>
+        (prev - 1 + (event.media?.length ?? 1)) % (event.media?.length ?? 1),
     );
   };
 
@@ -144,10 +138,12 @@ const EventDetail = () => {
                   ) : (
                     <div className="relative w-full h-96 bg-black">
                       <video
-                        src={currentMedia.url}
+                        src={resolveImagePath(currentMedia.url)}
                         className="w-full h-full object-cover"
                         controls
                         autoPlay
+                        muted
+                        playsInline
                       />
                     </div>
                   )

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { EventCard } from "@/components/EventCard";
 import { Event } from "@/lib/types/events";
 import { eventsAPI } from "@/lib/api";
-import { resolveImagePath } from "@/lib/utils";
+import { resolveImagePath, preloadImages } from "@/lib/utils";
 
 const Events = () => {
   const [events, setEvents] = useState<Event[]>([]);
@@ -45,10 +45,19 @@ const Events = () => {
             }
           });
 
+        const imageUrls = sortedEvents.flatMap((event: Event) =>
+          (event.media || [])
+            .filter(
+              (m: { type: string; url: string }) => m.type === "image" && m.url,
+            )
+            .slice(0, 1)
+            .map((m: { url: string }) => m.url),
+        );
+        await preloadImages(imageUrls);
+
         setEvents(sortedEvents);
       } catch (error) {
         console.error("Failed to load events:", error);
-        // Fallback to empty array if API fails
         setEvents([]);
       } finally {
         setLoading(false);

--- a/src/pages/OurMusicians.tsx
+++ b/src/pages/OurMusicians.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import MusiciansList from "@/components/MusiciansList";
 import { musiciansAPI } from "@/lib/api";
 import { Musician } from "@/lib/types/events";
+import { preloadImages } from "@/lib/utils";
 
 const OurMusicians = () => {
   const [musicians, setMusicians] = useState<Musician[]>([]);
@@ -12,6 +13,11 @@ const OurMusicians = () => {
       try {
         setLoading(true);
         const musiciansData = await musiciansAPI.getAll();
+        const photoUrls = musiciansData
+          .filter((m: Musician) => m.photo)
+          .map((m: Musician) => m.photo);
+        await preloadImages(photoUrls);
+
         setMusicians(musiciansData);
       } catch (error) {
         console.error("Failed to load musicians:", error);


### PR DESCRIPTION

- Auto-detect media type (image/video) from MIME type on file upload in admin, so videos are no longer saved with type "image" causing a gray placeholder
- Raise server upload limit from 10MB to 500MB to support video files; add per-type client-side check with a clear alert for oversized files
- Fix EventDetail video player: add resolveImagePath, muted, and playsInline so autoplay works across browsers
- Combine two sequential API calls in EventDetail into Promise.all so event details and musicians load together instead of staggered
- Preload all images (event media, musician photos) before removing the loading spinner so pages render complete rather than popping in piece by piece